### PR TITLE
refactor: suppression de la section Réflexions (blog) de la landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,41 +121,6 @@ title: Julien Bordet
   </div>
 </section>
 
-<!-- ========== RÉFLEXIONS ========== -->
-<section class="section section-light">
-  <div class="container">
-    <h2 class="section-title">Réflexions</h2>
-    <p class="section-subtitle">Géopolitique, technologie, science — ce qui mérite qu'on s'y attarde.</p>
-    <span class="section-divider"></span>
-    <div class="topics-grid">
-
-      <a href="/iran" class="topic-card">
-        <h3>Défense &amp; géopolitique</h3>
-        <p>Analyse des équilibres de puissance, souveraineté économique, monde iranien.</p>
-      </a>
-
-      <a href="/blog" class="topic-card">
-        <h3>Iran &amp; Moyen-Orient</h3>
-        <p>Suivi de la politique iranienne, lectures et analyses. زبان فارسی را صحبت می کنم</p>
-      </a>
-
-      <a href="/mac" class="topic-card">
-        <h3>Cybersécurité &amp; systèmes</h3>
-        <p>Sécurité des systèmes d'information, infrastructure, macOS.</p>
-      </a>
-
-      <a href="/physique" class="topic-card">
-        <h3>Physique &amp; cosmologie</h3>
-        <p>Cosmologie, physique fondamentale — le rêve d'astrophysicien qui ne m'a pas quitté.</p>
-      </a>
-
-    </div>
-    <div class="section-cta">
-      <a href="/blog" class="btn-outline" style="color: var(--navy); border-color: var(--navy);">Toutes les réflexions</a>
-    </div>
-  </div>
-</section>
-
 <!-- ========== CONTACT ========== -->
 <section class="section section-dark" id="contact">
   <div class="container" style="text-align:center;">


### PR DESCRIPTION
## Summary

- Suppression de la section « Réflexions » de la page d'accueil (index.html)
- La section listait des liens vers /iran, /blog, /mac, /physique — retirée pour simplifier la landing

## Test plan

- [ ] Vérifier que la page d'accueil s'affiche correctement sans la section Réflexions
- [ ] Vérifier que la section Contact reste bien présente juste après la section Parcours

🤖 Generated with [Claude Code](https://claude.com/claude-code)