### PR TITLE
feat: nouvelle tagline du hero — opposition stratégie/exécution

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Julien Bordet
   <div class="hero-ed-grid">
     <div class="hero-ed-main">
       <p class="kicker">Directeur Général — Direction opérationnelle</p>
-      <h1 class="hero-ed-tagline">Une stratégie ne vaut que si elle survit au contact du terrain.</h1>
+      <h1 class="hero-ed-tagline">La stratégie fixe le cap ; l'exécution fait la différence.</h1>
     </div>
     <div class="hero-ed-aside">
       <p>Vingt ans d'allers-retours entre la stratégie et sa mise en œuvre sur le terrain — en conseil comme à la direction de PME industrielles.</p>


### PR DESCRIPTION
Remplace « Une stratégie ne vaut que si elle survit au contact du terrain. » (décalque attendu de Moltke) par « La stratégie fixe le cap ; l'exécution fait la différence. » — antithèse plus nette, sans dévaloriser la stratégie.