### PR TITLE
fix(ci): résout les faux positifs du check de liens lychee

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         continue-on-error: true
         with:
-          args: --offline --no-progress _site
+          args: --offline --no-progress --base _site _site
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
En mode --offline, lychee inspecte les fichiers de _site/ sur disque et ne sait pas rattacher les liens root-relatifs (/css/main.css, /parcours, /blog/...) : il les comptait tous en erreur (~390 faux positifs), alors que ces liens sont valides une fois servis par GitHub Pages.

--base _site fixe la racine « / » sur le dossier _site/, ce qui élimine ces faux positifs et ne laisse remonter que les liens réellement cassés.