### PR TITLE
ci: passe les actions GitHub à Node.js 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -39,7 +39,7 @@ jobs:
         with:
           args: --offline --no-progress --base _site _site
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: _site
 


### PR DESCRIPTION
GitHub force les actions JS sur Node.js 24 à partir du 16 juin 2026 ; Node 20 sera retiré des runners le 16 septembre 2026.

- actions/checkout    v4 -> v5
- actions/upload-pages-artifact v3 -> v4 (Node 24, format d'artefact
  compatible avec deploy-pages@v4 qu'on conserve)

ruby/setup-ruby@v1 et lycheeverse/lychee-action@v2 suivent déjà une major sur Node 24, pas de changement nécessaire.