### PR TITLE
ci: finit la migration Node 24 (upload v5 + deploy v5)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           args: --offline --no-progress --base _site _site
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -51,4 +51,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Le bump v3->v4 d'upload-pages-artifact ne suffisait pas : sa v4 épingle en interne actions/upload-artifact@v4.6.2, encore en Node 20 (d'où le warning persistant sur le SHA ea165f8d). Sa v5 tire upload-artifact@v7 (Node 24).

deploy-pages@v4 est lui-même using:node20 et aurait déclenché le même warning ; v5 passe en node24. Upload v5 + deploy v5 forment l'appariement release/testé ensemble (format d'artefact compatible).

Plus aucune action en Node 20 dans le workflow.