### PR TITLE
fix(ci): corrige l'argument lychee (--root-dir au lieu de --base)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         continue-on-error: true
         with:
-          args: --offline --no-progress --base _site _site
+          args: --offline --no-progress --root-dir "$(pwd)/_site" _site
 
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
lychee v0.23 (installé par lychee-action@v2) refuse --base _site : « Base must either be a URL or an absolute local path (…) for root-relative links in local files, see --root-dir ».

Le bon argument pour résoudre les liens root-relatifs de fichiers locaux est --root-dir, avec un chemin absolu. --root-dir "$(pwd)/_site" fixe la racine « / » sur le dossier _site/ (forme recommandée par les exemples officiels de l'action).