### PR TITLE
ci: rend le check de liens lychee bloquant

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Check internal links
         uses: lycheeverse/lychee-action@v2
-        continue-on-error: true
         with:
           args: --offline --no-progress --root-dir "$(pwd)/_site" _site
 


### PR DESCRIPTION
Jusqu'ici l'étape portait continue-on-error: true : un lien mort sortait en exit code 2 mais le job restait vert, donc personne ne voyait le problème — un test qui ne sert à rien.

En retirant continue-on-error, un lien interne cassé fait désormais échouer le build (lychee-action a fail: true par défaut). Le check tourne en --offline : il ne teste que les fichiers locaux (les liens externes restent exclus), donc il n'échouera que sur de vrais liens internes morts, jamais sur un site externe momentanément indisponible.